### PR TITLE
Simplify DisjointSet.find()

### DIFF
--- a/disjoint_sets.py
+++ b/disjoint_sets.py
@@ -41,7 +41,7 @@ class DisjointSet:
     '''
     def find(self, n):
         if n.parent != n:
-            self.members[n.data].parent = self.find(n.parent)
+            n.parent = self.find(n.parent)
         return n.parent
 
     def union(self, n1, n2):


### PR DESCRIPTION
The find method in DisjointSet can be simplified.

Since n stays constant throughout the method there is no need to
re-look it up recursively in the members dictionary to update its parent.
Due to n staying constant, on line 44 we can write (n.parent = 
self.find(n.parent)) rather than (self.members[n.data].parent = 
self.find(n.parent)). This simplification of the find method does not
change the time complexity of the method, it just makes it more 
readable.

n stays constant throughout the find method so there is no need to 
look it up more than once in the members dictionary.